### PR TITLE
Entry point added for latest frontend

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -16,6 +16,10 @@ pub fn api_router(env: Env) -> Router {
     Router::new()
         // Identity/Auth routes
         .route("/identity/accounts/prelogin", post(accounts::prelogin))
+        .route(
+            "/identity/accounts/prelogin/password",
+            post(accounts::prelogin),
+        )
         .route("/identity/accounts/register", post(accounts::register))
         .route(
             "/identity/accounts/register/finish",


### PR DESCRIPTION
The latest front end of bitwarden requires a endpoint `/identity/accounts/prelogin/password`. Which was not supported. Add such endpoint so that the server could work with it.